### PR TITLE
Do not allow str/path for FeedProperty

### DIFF
--- a/src/p2g_eval/config/properties.py
+++ b/src/p2g_eval/config/properties.py
@@ -6,20 +6,13 @@ from custom_conf.properties.nested_property import NestedTypeProperty
 from custom_conf.properties.property import Property
 
 from p2g_eval.datastructures.gtfs.feed import Feed
-from p2g_eval.in_out.feed_reader import BaseFeedReader
 
 
 class FeedProperty(Property):
     def __init__(self, name: str) -> None:
         super().__init__(name, Feed)
 
-    def __set__(self, instance, value: Feed | Path) -> None:
-        # Allow paths as well.
-        if isinstance(value, str):
-            value = Path(value)
-        if isinstance(value, Path) and value.exists():
-            value = BaseFeedReader(value).read()
-
+    def __set__(self, instance, value: Feed) -> None:
         super().__set__(instance, value)
 
 

--- a/test/test_config/test_config.py
+++ b/test/test_config/test_config.py
@@ -31,16 +31,15 @@ class TestP2GConfig(TestCase):
     def test_load_args_dict(self) -> None:
         true_feed = BaseFeedReader(TEST_DATA_DIR.joinpath("vag.zip")).read()
         test_feed_path = TEST_DATA_DIR.joinpath("p2g_vag_1.zip")
+        test_feed = BaseFeedReader(test_feed_path).read()
         stop_mapping = TEST_DATA_DIR.joinpath("stop_mapping.csv")
-        values = {"test_feed": test_feed_path,
+        values = {"test_feed": test_feed,
                   "true_feed": true_feed,
                   "stop_mapping": stop_mapping}
         c = P2GConfig()
         c.load_args_dict(values)
-        self.assertEqual(id(true_feed), id(c.true_feed))
-        test_feed = BaseFeedReader(test_feed_path).read()
         self.assertTrue(test_feed == c.test_feed)
-        self.assertNotEqual(id(test_feed), id(c.test_feed))
+        self.assertEqual(id(test_feed), id(c.test_feed))
         with open(stop_mapping) as fil:
             contents = fil.read()
         mapping = [tuple(line.split(",")) for line in contents.split("\n")[1:]


### PR DESCRIPTION
What's not working right now, is the reading of the feeds using command line arguments.
One way of solving this would be to add *_feed_path properties, which only contain the path, which are then used to populate the `FeedProperty`, should it not exist. Technically these could also be read in the background by a different thread/process.